### PR TITLE
Add circle-stroke-width as 0

### DIFF
--- a/datasets/ATL08_v004.json
+++ b/datasets/ATL08_v004.json
@@ -74,7 +74,8 @@
                 ]
             ]
         },
-        "circle-stroke-color": "white"
+        "circle-stroke-color": "white",
+        "circle-stroke-width": 0
     },
     "legend": {
         "type": "gradient",


### PR DESCRIPTION
I can't really tell why these 2 api deployments of the atl08 dataset are different:
* https://jsvuwyxsjh.execute-api.us-west-2.amazonaws.com/v1/datasets/atl08_v004 (DIT/main branch deployment)
* https://f5lwsxlvgi.execute-api.us-west-2.amazonaws.com/v1/datasets/atl08_v004 (aimee deployment)

but there are no related changes between the API branches https://github.com/MAAP-Project/biomass-dashboard-api/compare/main...aimee

The former has a `null` circle-stroke-width which is causing the dashboard to throw an error.