### PR TITLE
Fix: GEDI image display

### DIFF
--- a/products/GEDI_L4B/summary.html
+++ b/products/GEDI_L4B/summary.html
@@ -5,7 +5,7 @@
 
 <div style="text-align: center;">
   <figure>
-    <img src="/maap-biomass/assets/graphics/content/products/gedi_1.png" />
+    <img src="/maap-biomass/assets/graphics/content/products/gedi_1.png" style="height: 280px;"/>
     <figcaption>Mean (top) and Standard Error (bottom) of 1 km Biomass in GEDI’s gridded biomass product.</figcaption>
   </figure>
 </div>


### PR DESCRIPTION
Sets a height for the GEDI image so the whole of the image is displayed on the dashboard