### PR TITLE
Gedi cal/val data should be on the GEDI page

### DIFF
--- a/products/GEDI_L4B/product.json
+++ b/products/GEDI_L4B/product.json
@@ -39,5 +39,9 @@
     90
   ],
   "indicators": [],
-  "datasets": []
+  "datasets": [
+    {
+        "id": "gedi_calval_plots"
+    }
+  ]
 }

--- a/products/ICESat2_Boreal/product.json
+++ b/products/ICESat2_Boreal/product.json
@@ -51,9 +51,6 @@
         },
         {
             "id": "icesat2_boreal_topo"
-        },
-        {
-            "id": "gedi_calval_plots"
         }
     ]
 }


### PR DESCRIPTION
Per request from Laura Duncanson, we are moving the GEDI Cal/Val points from ICESat-2 to GEDI L4B