### PR TITLE
Update ICESat2_boreal_biomass geojson, remove bad tiles

### DIFF
--- a/datasets/ICESat2_boreal_biomass.json
+++ b/datasets/ICESat2_boreal_biomass.json
@@ -9,7 +9,7 @@
   "source": {
     "type": "raster",
     "tiles": [
-      "https://titiler.maap-project.org/mosaicjson/mosaics/e7e26f4d-9a2f-4a3b-9256-0821e372e40e/tiles/{z}/{x}/{y}/tiles/{z}/{x}/{y}.png?bidx=1&rescale=0,400&colormap_name=gist_earth_r"
+      "https://titiler.maap-project.org/mosaicjson/mosaics/e7e26f4d-9a2f-4a3b-9256-0821e372e40e/tiles/{z}/{x}/{y}.png?bidx=1&rescale=0,400&colormap_name=gist_earth_r"
     ]
   },
   "legend": {

--- a/datasets/ICESat2_boreal_biomass_se.json
+++ b/datasets/ICESat2_boreal_biomass_se.json
@@ -9,7 +9,7 @@
   "source": {
     "type": "raster",
     "tiles": [
-      "https://titiler.maap-project.org/mosaicjson/mosaics/e7e26f4d-9a2f-4a3b-9256-0821e372e40e/tiles/{z}/{x}/{y}/tiles/{z}/{x}/{y}.png?bidx=2&rescale=0%2C20&colormap_name=reds"
+      "https://titiler.maap-project.org/mosaicjson/mosaics/e7e26f4d-9a2f-4a3b-9256-0821e372e40e/tiles/{z}/{x}/{y}.png?bidx=2&rescale=0%2C20&colormap_name=reds"
     ]
   },
   "legend": {


### PR DESCRIPTION
This swaps the mosaicjson for a new copy that removes v1 tiles from v2 provisional mosaic (bad tiles in the ocean). It also attempts to improve performance by adding overviews to the data, compression data at rest, and finding the balance of mosaicjson size to index usability, with a zoom 8 focus.

After merging to test, we should benchmark against production. But the tile fix is the most important time critical feature.