### PR TITLE
fix: ICESat2-Boreal biomass layers

### DIFF
--- a/datasets/ICESat2_boreal_biomass.json
+++ b/datasets/ICESat2_boreal_biomass.json
@@ -10,7 +10,7 @@
     "type": "raster",
     "minzoom": 7,
     "tiles": [
-      "https://titiler.maap-project.org/mosaics/e7027568-3a10-472d-a96b-3d0c81aadc6d/tiles/{z}/{x}/{y}.png?bidx=1&rescale=0,400&colormap_name=gist_earth_r&color_formula=gamma r {gamma}"
+      "https://titiler.maap-project.org/mosaics/cb39d9f9-4b7b-4812-a350-629f9f27fa3a/tiles/{z}/{x}/{y}.png?bidx=1&rescale=0,400&colormap_name=gist_earth_r&color_formula=gamma r {gamma}"
     ]
   },
   "legend": {

--- a/datasets/ICESat2_boreal_biomass_se.json
+++ b/datasets/ICESat2_boreal_biomass_se.json
@@ -10,7 +10,7 @@
     "type": "raster",
     "minzoom": 8,
     "tiles": [
-      "https://titiler.maap-project.org/mosaics/e7027568-3a10-472d-a96b-3d0c81aadc6d/tiles/{z}/{x}/{y}.png?bidx=2&rescale=0%2C20&colormap_name=reds&color_formula=gamma r {gamma}"
+      "https://titiler.maap-project.org/mosaics/cb39d9f9-4b7b-4812-a350-629f9f27fa3a/tiles/{z}/{x}/{y}.png?bidx=2&rescale=0%2C20&colormap_name=reds&color_formula=gamma r {gamma}"
     ]
   },
   "legend": {


### PR DESCRIPTION
Tested using:
```
import requests
from folium import Map, TileLayer

m = Map(
    tiles="OpenStreetMap",
    zoom_start=5
)

tiles = TileLayer(
    tiles="https://titiler.maap-project.org/mosaics/cb39d9f9-4b7b-4812-a350-629f9f27fa3a/tiles/{z}/{x}/{y}.png?bidx=1&rescale=0,400&colormap_name=gist_earth_r",
    min_zoom=8,
    max_zoom=12,
    opacity=1,
    attr="MAAP"
)

tiles.add_to(m)
m
```
<img width="608" alt="image" src="https://github.com/MAAP-Project/biomass-dashboard-datasets/assets/50224594/2bc5a5fe-3cf1-406c-af97-d04e1163190c">
