### PR TITLE
Change mosaic links to point to ESA CCI V4 dataset mosaics

### DIFF
--- a/datasets/CCI_BIOMASS.json
+++ b/datasets/CCI_BIOMASS.json
@@ -9,7 +9,7 @@
   "source": {
     "type": "raster",
     "tiles": [
-      "https://0x78e0jyvl.execute-api.us-west-2.amazonaws.com/mosaic/3f4af3705f7801257a6bc856d662440a/tiles/{z}/{x}/{y}?assets=estimates&rescale=0,400&bidx=1&colormap_name=gist_earth_r&color_formula=gamma r {gamma}"
+      "https://titiler-pgstac.maap-project.org/mosaic/3f4af3705f7801257a6bc856d662440a/tiles/{z}/{x}/{y}?assets=estimates&rescale=0,400&bidx=1&colormap_name=gist_earth_r&color_formula=gamma r {gamma}"
     ]
   },
   "legend": {

--- a/datasets/CCI_BIOMASS_SD.json
+++ b/datasets/CCI_BIOMASS_SD.json
@@ -9,7 +9,7 @@
   "source": {
     "type": "raster",
     "tiles": [
-      "https://0x78e0jyvl.execute-api.us-west-2.amazonaws.com/mosaic/3f4af3705f7801257a6bc856d662440a/tiles/{z}/{x}/{y}?assets=standard_deviation&rescale=0,400&bidx=1&colormap_name=reds&color_formula=gamma r {gamma}"
+      "https://titiler-pgstac.maap-project.org/mosaic/3f4af3705f7801257a6bc856d662440a/tiles/{z}/{x}/{y}?assets=standard_deviation&rescale=0,400&bidx=1&colormap_name=reds&color_formula=gamma r {gamma}"
     ]
   },
   "legend": {


### PR DESCRIPTION
## Issue 

https://github.com/NASA-IMPACT/active-maap-sprint/issues/618

## Context

We recently : 

- deployed a titiler-pgstac instance that has access to the MAAP STAC database. Here is the endpoint https://0x78e0jyvl.execute-api.us-west-2.amazonaws.com/docs. 
- updated the version of the CCI dataset in the STAC catalog CCI collection, to version 4.

Therefore, we wanted to make use of this new titiler to create a mosaic directly from the STAC database with this updated collection, and make use of the mosaic in the MAAP dashboard.

## What does this PR do ?

This PR changes the CCI mosaic URL, in order to point to the updated dataset, version 4.

## Implementation details

I changed the dataset links so that they point to the endpoint of the new titiler pgstac application that returns the corresponding mosaic (estimates or standard deviation). [I created the mosaic with this notebook.](https://gist.github.com/emileten/02f2c8027670996949bd709608481361) Note that we do not yet have a custom domain pointing to this titiler so I have to use the API gateway endpoint. 

## Checklist 

- [x] tested locally 