### PR TITLE
Change  NASA JPL mosaic link to use titiler-pgstac

### DIFF
--- a/datasets/nasa_jpl.json
+++ b/datasets/nasa_jpl.json
@@ -9,7 +9,7 @@
   "source": {
     "type": "raster",
     "tiles": [
-      "https://titiler.maap-project.org/mosaics/f0e6f941-4e50-46b3-9463-11b3c2181662/tiles/{z}/{x}/{y}?bidx=1&max_size=1024&resampling_method=nearest&rescale=0,400&return_mask=true&colormap_name=gist_earth_r&color_formula=gamma r {gamma}"
+      "https://titiler-pgstac.maap-project.org/mosaic/a1be63611e087f52f8194bf2c38a6c90/tiles/{z}/{x}/{y}?assets=mean&bidx=1&max_size=1024&resampling_method=nearest&rescale=0,400&return_mask=true&colormap_name=gist_earth_r&color_formula=gamma r {gamma}"
     ]
   },
   "legend": {

--- a/datasets/nasa_jpl_se.json
+++ b/datasets/nasa_jpl_se.json
@@ -9,7 +9,7 @@
   "source": {
     "type": "raster",
     "tiles": [
-      "https://titiler.maap-project.org/mosaics/210e8e5d-35c0-4549-8fc1-2b2145ad6ecf/tiles/{z}/{x}/{y}?bidx=1&max_size=1024&resampling_method=nearest&rescale=0,150&return_mask=true&colormap_name=reds&nodata=0&color_formula=gamma r {gamma}"
+      "https://titiler-pgstac.maap-project.org/mosaic/a1be63611e087f52f8194bf2c38a6c90/tiles/{z}/{x}/{y}?assets=standard_deviation&bidx=1&max_size=1024&resampling_method=nearest&rescale=0,150&return_mask=true&colormap_name=reds&nodata=0&color_formula=gamma r {gamma}"
     ]
   },
   "legend": {


### PR DESCRIPTION
## Issue 

https://github.com/NASA-IMPACT/active-maap-sprint/issues/652

## Context

See https://github.com/MAAP-Project/biomass-dashboard-datasets/pull/106 for context, same applies here.

## What does this PR do ?

This PR changes the NASA JPL mosaic URL, in order to point to the titiler-pgstac based mosaic. 

## Implementation details

I changed the dataset links so that they point to the endpoint of the new titiler pgstac application that returns the corresponding mosaic (estimates or standard deviation). [I created the mosaic with this notebook, swapping the collection name to use NASA JPL](https://gist.github.com/emileten/02f2c8027670996949bd709608481361).

## Checklist 

- [x] tested locally 