### PR TITLE
Specify TMS in all tile URLs

### DIFF
--- a/datasets/CCI_BIOMASS.json
+++ b/datasets/CCI_BIOMASS.json
@@ -9,7 +9,7 @@
   "source": {
     "type": "raster",
     "tiles": [
-      "https://titiler.maap-project.org/mosaic/4f2b21b1d359e0169117e84c35ed5f7d/tiles/{z}/{x}/{y}?assets=estimates&rescale=0,400&bidx=1&colormap_name=gist_earth_r&color_formula=gamma r {gamma}"
+      "https://titiler.maap-project.org/mosaic/4f2b21b1d359e0169117e84c35ed5f7d/tiles/WebMercatorQuad/{z}/{x}/{y}?assets=estimates&rescale=0,400&bidx=1&colormap_name=gist_earth_r&color_formula=gamma r {gamma}"
     ]
   },
   "legend": {

--- a/datasets/CCI_BIOMASS_SD.json
+++ b/datasets/CCI_BIOMASS_SD.json
@@ -9,7 +9,7 @@
   "source": {
     "type": "raster",
     "tiles": [
-      "https://titiler.maap-project.org/mosaic/4f2b21b1d359e0169117e84c35ed5f7d/tiles/{z}/{x}/{y}?assets=standard_deviation&rescale=0,500&bidx=2&colormap_name=reds&color_formula=gamma r {gamma}"
+      "https://titiler.maap-project.org/mosaic/4f2b21b1d359e0169117e84c35ed5f7d/tiles/WebMercatorQuad/{z}/{x}/{y}?assets=standard_deviation&rescale=0,500&bidx=2&colormap_name=reds&color_formula=gamma r {gamma}"
     ]
   },
   "legend": {

--- a/datasets/GEDI_L4B.json
+++ b/datasets/GEDI_L4B.json
@@ -9,7 +9,7 @@
   "source": {
     "type": "raster",
     "tiles": [
-      "https://titiler.maap-project.org/cog/tiles/{z}/{x}/{y}.png?url=s3://ornl-cumulus-prod-protected/gedi/GEDI_L4B_Gridded_Biomass_V2_1/data/GEDI04_B_MW019MW223_02_002_02_R01000M_MU.tif&rescale=0,400&colormap_name=gist_earth_r&color_formula=gamma r {gamma}"
+      "https://titiler.maap-project.org/cog/tiles/WebMercatorQuad/{z}/{x}/{y}.png?url=s3://ornl-cumulus-prod-protected/gedi/GEDI_L4B_Gridded_Biomass_V2_1/data/GEDI04_B_MW019MW223_02_002_02_R01000M_MU.tif&rescale=0,400&colormap_name=gist_earth_r&color_formula=gamma r {gamma}"
     ]
   },
   "legend": {

--- a/datasets/GEDI_L4B_SE.json
+++ b/datasets/GEDI_L4B_SE.json
@@ -9,7 +9,7 @@
   "source": {
     "type": "raster",
     "tiles": [
-      "https://titiler.maap-project.org/cog/tiles/{z}/{x}/{y}.png?url=s3://ornl-cumulus-prod-protected/gedi/GEDI_L4B_Gridded_Biomass_V2_1/data/GEDI04_B_MW019MW223_02_002_02_R01000M_SE.tif&rescale=0,310&colormap_name=reds&color_formula=gamma r {gamma}"
+      "https://titiler.maap-project.org/cog/tiles/WebMercatorQuad/{z}/{x}/{y}.png?url=s3://ornl-cumulus-prod-protected/gedi/GEDI_L4B_Gridded_Biomass_V2_1/data/GEDI04_B_MW019MW223_02_002_02_R01000M_SE.tif&rescale=0,310&colormap_name=reds&color_formula=gamma r {gamma}"
     ]
   },
   "legend": {

--- a/datasets/ICESat2_boreal_biomass.json
+++ b/datasets/ICESat2_boreal_biomass.json
@@ -10,7 +10,7 @@
     "type": "raster",
     "minzoom": 7,
     "tiles": [
-      "https://titiler.maap-project.org/collections/icesat2-boreal/tiles/{z}/{x}/{y}.png?assets=tif&bidx=1&rescale=0,400&colormap_name=gist_earth_r&color_formula=gamma r {gamma}"
+      "https://titiler.maap-project.org/collections/icesat2-boreal/tiles/WebMercatorQuad/{z}/{x}/{y}.png?assets=tif&bidx=1&rescale=0,400&colormap_name=gist_earth_r&color_formula=gamma r {gamma}"
     ]
   },
   "legend": {

--- a/datasets/ICESat2_boreal_biomass_reduced.json
+++ b/datasets/ICESat2_boreal_biomass_reduced.json
@@ -10,7 +10,7 @@
     "type": "raster",
     "maxzoom": 7,
     "tiles": [
-      "https://titiler.maap-project.org/cog/tiles/{z}/{x}/{y}.png?url=s3://nasa-maap-data-store/file-staging/dashboard-datasets/icesat2-boreal/AGB_tindex_average_4500m.tif&bidx=1&rescale=0,400&colormap_name=gist_earth_r&color_formula=gamma r {gamma}"
+      "https://titiler.maap-project.org/cog/tiles/WebMercatorQuad/{z}/{x}/{y}.png?url=s3://nasa-maap-data-store/file-staging/dashboard-datasets/icesat2-boreal/AGB_tindex_average_4500m.tif&bidx=1&rescale=0,400&colormap_name=gist_earth_r&color_formula=gamma r {gamma}"
     ]
   },
   "legend": {

--- a/datasets/ICESat2_boreal_biomass_se.json
+++ b/datasets/ICESat2_boreal_biomass_se.json
@@ -10,7 +10,7 @@
     "type": "raster",
     "minzoom": 8,
     "tiles": [
-      "https://titiler.maap-project.org/collections/icesat2-boreal/tiles/{z}/{x}/{y}.png?assets=tif&bidx=2&rescale=0%2C20&colormap_name=reds&color_formula=gamma r {gamma}"
+      "https://titiler.maap-project.org/collections/icesat2-boreal/tiles/WebMercatorQuad/{z}/{x}/{y}.png?assets=tif&bidx=2&rescale=0%2C20&colormap_name=reds&color_formula=gamma r {gamma}"
     ]
   },
   "legend": {

--- a/datasets/NCEO_Africa.json
+++ b/datasets/NCEO_Africa.json
@@ -9,7 +9,7 @@
   "source": {
     "type": "raster",
     "tiles": [
-      "{titiler_server_url}/cog/tiles/{z}/{x}/{y}.png?url=s3://maap-landing-zone-gccops/user-added/uploaded_objects/ae841191-8a43-4226-9c5e-db4f500adb45/AGB_map_2017v0m_COG.tif&rescale=0,400&colormap_name=gist_earth_r&color_formula=gamma r {gamma}"
+      "{titiler_server_url}/cog/tiles/WebMercatorQuad/{z}/{x}/{y}.png?url=s3://maap-landing-zone-gccops/user-added/uploaded_objects/ae841191-8a43-4226-9c5e-db4f500adb45/AGB_map_2017v0m_COG.tif&rescale=0,400&colormap_name=gist_earth_r&color_formula=gamma r {gamma}"
     ]
   },
   "legend": {

--- a/datasets/NCEO_Africa_SD.json
+++ b/datasets/NCEO_Africa_SD.json
@@ -9,7 +9,7 @@
   "source": {
     "type": "raster",
     "tiles": [
-      "{titiler_server_url}/cog/tiles/{z}/{x}/{y}.png?url=s3://maap-landing-zone-gccops/user-added/uploaded_objects/96a28977-02db-46a0-8429-70f5b4267d38/SD_map_2017v0m_COG.tif&rescale=0%2C310&colormap_name=reds&color_formula=gamma r {gamma}"
+      "{titiler_server_url}/cog/tiles/WebMercatorQuad/{z}/{x}/{y}.png?url=s3://maap-landing-zone-gccops/user-added/uploaded_objects/96a28977-02db-46a0-8429-70f5b4267d38/SD_map_2017v0m_COG.tif&rescale=0%2C310&colormap_name=reds&color_formula=gamma r {gamma}"
     ]
   },
   "legend": {

--- a/datasets/paraguay-estimated-biomass.json
+++ b/datasets/paraguay-estimated-biomass.json
@@ -9,7 +9,7 @@
   "source": {
     "type": "raster",
     "tiles": [
-      "{titiler_server_url}/cog/tiles/{z}/{x}/{y}.png?url=s3://maap-landing-zone-gccops/user-added/uploaded_objects/0bfec58c-45fb-464e-b301-b1afbdf5249e/5_biomass_cog.masked.tif&nodata=0&bidx=1&rescale=0,400&colormap_name=gist_earth_r&color_formula=gamma r {gamma}"
+      "{titiler_server_url}/cog/tiles/WebMercatorQaud/{z}/{x}/{y}.png?url=s3://maap-landing-zone-gccops/user-added/uploaded_objects/0bfec58c-45fb-464e-b301-b1afbdf5249e/5_biomass_cog.masked.tif&nodata=0&bidx=1&rescale=0,400&colormap_name=gist_earth_r&color_formula=gamma r {gamma}"
     ]
   },
   "legend": {

--- a/datasets/paraguay-forest-mask.json
+++ b/datasets/paraguay-forest-mask.json
@@ -9,7 +9,7 @@
   "source": {
     "type": "raster",
     "tiles": [
-      "{titiler_server_url}/cog/tiles/{z}/{x}/{y}.png?url=s3://maap-landing-zone-gccops/user-added/uploaded_objects/45fe2e6f-2007-4cb1-964a-f337f39f4fdc/1_forest_cog.masked.tif&rescale=0,1&nodata=0&colormap_name=greens"
+      "{titiler_server_url}/cog/tiles/WebMercatorQuad/{z}/{x}/{y}.png?url=s3://maap-landing-zone-gccops/user-added/uploaded_objects/45fe2e6f-2007-4cb1-964a-f337f39f4fdc/1_forest_cog.masked.tif&rescale=0,1&nodata=0&colormap_name=greens"
     ]
   },
   "legend": {

--- a/datasets/paraguay-tree-cover.json
+++ b/datasets/paraguay-tree-cover.json
@@ -9,17 +9,14 @@
   "source": {
     "type": "raster",
     "tiles": [
-      "{titiler_server_url}/cog/tiles/{z}/{x}/{y}.png?url=s3://maap-landing-zone-gccops/user-added/uploaded_objects/ee5eb60c-3c01-4789-ae8e-c03f1d719440/4_tree_cover_cog.masked.tif&rescale=0,75&nodata=0&colormap_name=greens&color_formula=gamma r {gamma}"
+      "{titiler_server_url}/cog/tiles/WebMercatorQuad/{z}/{x}/{y}.png?url=s3://maap-landing-zone-gccops/user-added/uploaded_objects/ee5eb60c-3c01-4789-ae8e-c03f1d719440/4_tree_cover_cog.masked.tif&rescale=0,75&nodata=0&colormap_name=greens&color_formula=gamma r {gamma}"
     ]
   },
   "legend": {
     "type": "gradient-adjustable",
     "min": "0",
     "max": "75",
-    "stops": [
-      "#f7fcf5",
-      "#00441b"
-    ]
+    "stops": ["#f7fcf5", "#00441b"]
   },
   "info": "Percent (%) Tree cover for 2019."
 }


### PR DESCRIPTION
This is part of the work for upgrading to the latest version of `titiler` ( https://github.com/NASA-IMPACT/active-maap-sprint/issues/1103) which deprecated the behavior defaulting to `WebMercatorQuad`.