### PR TITLE
only show the DAAC subset of tiles in the icesat2-boreal dataset

### DIFF
--- a/datasets/ICESat2_boreal_biomass.json
+++ b/datasets/ICESat2_boreal_biomass.json
@@ -10,7 +10,7 @@
     "type": "raster",
     "minzoom": 7,
     "tiles": [
-      "https://titiler.maap-project.org/collections/icesat2-boreal-v2.1-agb/tiles/WebMercatorQuad/{z}/{x}/{y}.png?assets=cog&bidx=1&rescale=0,400&colormap_name=gist_earth_r&color_formula=gamma r {gamma}"
+      "https://titiler.maap-project.org/collections/icesat2-boreal-v3.0-agb/tiles/WebMercatorQuad/{z}/{x}/{y}.png?assets=cog&bidx=1&rescale=0,400&colormap_name=gist_earth_r&color_formula=gamma r {gamma}"
     ]
   },
   "legend": {

--- a/datasets/ICESat2_boreal_biomass.json
+++ b/datasets/ICESat2_boreal_biomass.json
@@ -10,7 +10,7 @@
     "type": "raster",
     "minzoom": 7,
     "tiles": [
-      "https://titiler.maap-project.org/collections/icesat2-boreal-v3.0-agb/tiles/WebMercatorQuad/{z}/{x}/{y}.png?assets=cog&bidx=1&rescale=0,400&colormap_name=gist_earth_r&color_formula=gamma r {gamma}"
+      "https://titiler.maap-project.org/searches/76c04112ddbe5d4fa938c24a88855882/tiles/WebMercatorQuad/{z}/{x}/{y}.png?assets=cog&bidx=1&rescale=0,400&colormap_name=gist_earth_r&color_formula=gamma r {gamma}"
     ]
   },
   "legend": {

--- a/datasets/ICESat2_boreal_biomass_reduced.json
+++ b/datasets/ICESat2_boreal_biomass_reduced.json
@@ -10,7 +10,7 @@
     "type": "raster",
     "maxzoom": 7,
     "tiles": [
-      "https://titiler.maap-project.org/cog/tiles/WebMercatorQuad/{z}/{x}/{y}.png?url=s3://nasa-maap-data-store/file-staging/dashboard-datasets/icesat2-boreal-v3.0-agb-downsampled-300m-35N-80N.tif&bidx=1&rescale=0,400&colormap_name=gist_earth_r&color_formula=gamma r {gamma}"
+      "https://titiler.maap-project.org/cog/tiles/WebMercatorQuad/{z}/{x}/{y}.png?url=s3://nasa-maap-data-store/file-staging/dashboard-datasets/icesat2-boreal-v3.0-agb-downsampled-300m-daac.tif&bidx=1&rescale=0,400&colormap_name=gist_earth_r&color_formula=gamma r {gamma}"
     ]
   },
   "legend": {

--- a/datasets/ICESat2_boreal_biomass_reduced.json
+++ b/datasets/ICESat2_boreal_biomass_reduced.json
@@ -10,7 +10,7 @@
     "type": "raster",
     "maxzoom": 7,
     "tiles": [
-      "https://titiler.maap-project.org/cog/tiles/WebMercatorQuad/{z}/{x}/{y}.png?url=s3://nasa-maap-data-store/file-staging/dashboard-datasets/icesat2-boreal/AGB_tindex_average_4500m.tif&bidx=1&rescale=0,400&colormap_name=gist_earth_r&color_formula=gamma r {gamma}"
+      "https://titiler.maap-project.org/cog/tiles/WebMercatorQuad/{z}/{x}/{y}.png?url=s3://nasa-maap-data-store/file-staging/dashboard-datasets/icesat2-boreal-v3.0-agb-downsampled-300m-35N-80N.tif&bidx=1&rescale=0,400&colormap_name=gist_earth_r&color_formula=gamma r {gamma}"
     ]
   },
   "legend": {

--- a/datasets/ICESat2_boreal_biomass_se.json
+++ b/datasets/ICESat2_boreal_biomass_se.json
@@ -10,7 +10,7 @@
     "type": "raster",
     "minzoom": 8,
     "tiles": [
-      "https://titiler.maap-project.org/collections/icesat2-boreal-v2.1-agb/tiles/WebMercatorQuad/{z}/{x}/{y}.png?assets=cog&bidx=2&rescale=0%2C20&colormap_name=reds&color_formula=gamma r {gamma}"
+      "https://titiler.maap-project.org/collections/icesat2-boreal-v3.0-agb/tiles/WebMercatorQuad/{z}/{x}/{y}.png?assets=cog&bidx=2&rescale=0%2C20&colormap_name=reds&color_formula=gamma r {gamma}"
     ]
   },
   "legend": {

--- a/datasets/ICESat2_boreal_biomass_se.json
+++ b/datasets/ICESat2_boreal_biomass_se.json
@@ -10,7 +10,7 @@
     "type": "raster",
     "minzoom": 8,
     "tiles": [
-      "https://titiler.maap-project.org/collections/icesat2-boreal-v3.0-agb/tiles/WebMercatorQuad/{z}/{x}/{y}.png?assets=cog&bidx=2&rescale=0%2C20&colormap_name=reds&color_formula=gamma r {gamma}"
+      "https://titiler.maap-project.org/searches/76c04112ddbe5d4fa938c24a88855882/tiles/WebMercatorQuad/{z}/{x}/{y}.png?assets=cog&bidx=2&rescale=0%2C20&colormap_name=reds&color_formula=gamma r {gamma}"
     ]
   },
   "legend": {


### PR DESCRIPTION
After discussion with @pahbs I created a titiler-pgstac mosaic/search that only includes the the official tiles that are in the DAAC (not any of the southerly test tiles). I also created a 300 meter downsampled copy of those tiles.